### PR TITLE
Fix GitHub Actions documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,11 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install dependencies
+      - name: Install package in development mode
+        run: |
+          uv pip install --system -e .
+
+      - name: Install documentation dependencies
         run: |
           uv pip install --system mkdocs mkdocs-material mkdocs-autorefs mkdocstrings[python] pymdown-extensions
 


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow to install package dependencies before building documentation
- Add separate step to install ita_scrapper package in development mode
- Allows mkdocstrings to import modules and generate API documentation

## Problem
The previous workflow failed with:
```
ERROR - mkdocstrings: ModuleNotFoundError: No module named 'ita_scrapper'
ERROR - Could not collect 'ita_scrapper.scrapper.ITAScrapper'
```

## Solution
Install the package in development mode before building docs:
```yaml
- name: Install package in development mode
  run: uv pip install --system -e .
```

## Test plan
- [x] Documentation builds successfully locally
- [x] API documentation generates from Python modules
- [x] All mkdocstrings imports work correctly
- [x] GitHub Actions workflow should now complete successfully

🤖 Generated with [opencode](https://opencode.ai)